### PR TITLE
Added updateItem functionlity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,20 @@ Configuration options
   * Default: 3000
   * Importance: medium
 
+``use.updates``
+  Whether to use DynamoDB update api instead of insert api.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
+``table.keys.names``
+  List of ``[hash_key_name,[range_key_name]]``. Must be given when using the use.updates flag.
+
+  * Type: list
+  * Default: []
+  * Importance: medium
+
 Source Connector
 ================
 

--- a/src/main/java/dynamok/sink/AttributeValueConverter.java
+++ b/src/main/java/dynamok/sink/AttributeValueConverter.java
@@ -17,6 +17,7 @@
 package dynamok.sink;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;

--- a/src/main/java/dynamok/sink/DynamoDbSinkTask.java
+++ b/src/main/java/dynamok/sink/DynamoDbSinkTask.java
@@ -176,7 +176,6 @@ public class DynamoDbSinkTask extends SinkTask {
                 updateItem.addKeyEntry(topAttributeName,attributeValueUpdate.getValue());
             }
             else {
-                log.info("tableKeysNames {} does not contain topAttributeName {}",config.tableKeysNames,topAttributeName);
                 updateItem.addAttributeUpdatesEntry(topAttributeName, attributeValueUpdate);
             }
         } else if (attributeValue.getM() != null) {

--- a/src/main/java/dynamok/sink/DynamoDbSinkTask.java
+++ b/src/main/java/dynamok/sink/DynamoDbSinkTask.java
@@ -19,14 +19,7 @@ package dynamok.sink;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
-import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
-import com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult;
-import com.amazonaws.services.dynamodbv2.model.LimitExceededException;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
-import com.amazonaws.services.dynamodbv2.model.PutRequest;
-import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.amazonaws.services.dynamodbv2.model.*;
 import dynamok.Version;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -94,19 +87,11 @@ public class DynamoDbSinkTask extends SinkTask {
         if (records.isEmpty()) return;
 
         try {
-            if (records.size() == 1 || config.batchSize == 1) {
-                for (final SinkRecord record : records) {
-                    client.putItem(tableName(record), toPutRequest(record).getItem());
-                }
-            } else {
-                final Iterator<SinkRecord> recordIterator = records.iterator();
-                while (recordIterator.hasNext()) {
-                    final Map<String, List<WriteRequest>> writesByTable = toWritesByTable(recordIterator);
-                    final BatchWriteItemResult batchWriteResponse = client.batchWriteItem(new BatchWriteItemRequest(writesByTable));
-                    if (!batchWriteResponse.getUnprocessedItems().isEmpty()) {
-                        throw new UnprocessedItemsException(batchWriteResponse.getUnprocessedItems());
-                    }
-                }
+            if (config.useUpdates){
+                updateItems(records);
+            }
+            else {
+                putItems(records);
             }
         } catch (LimitExceededException | ProvisionedThroughputExceededException e) {
             log.debug("Write failed with Limit/Throughput Exceeded exception; backing off");
@@ -171,6 +156,85 @@ public class DynamoDbSinkTask extends SinkTask {
         } else {
             throw new ConnectException("No top attribute name configured for " + valueSource + ", and it could not be converted to Map: " + attributeValue);
         }
+    }
+
+    private void insertUpdate(ValueSource valueSource, Schema schema, Object value, UpdateItemRequest updateItem) {
+        final AttributeValue attributeValue;
+        try {
+            attributeValue = schema == null
+                    ? AttributeValueConverter.toAttributeValueSchemaless(value)
+                    : AttributeValueConverter.toAttributeValue(schema, value);
+        } catch (DataException e) {
+            log.error("Failed to convert record with schema={} value={}", schema, value, e);
+            throw e;
+        }
+
+        final String topAttributeName = valueSource.topAttributeName(config);
+        if (!topAttributeName.isEmpty()) {
+            AttributeValueUpdate attributeValueUpdate = new AttributeValueUpdate().withValue(attributeValue);
+            if (config.tableKeysNames.contains(topAttributeName)){
+                updateItem.addKeyEntry(topAttributeName,attributeValueUpdate.getValue());
+            }
+            else {
+                log.info("tableKeysNames {} does not contain topAttributeName {}",config.tableKeysNames,topAttributeName);
+                updateItem.addAttributeUpdatesEntry(topAttributeName, attributeValueUpdate);
+            }
+        } else if (attributeValue.getM() != null) {
+            Map<String,AttributeValue> attributeValueMap = attributeValue.getM();
+            config.tableKeysNames.forEach((k) -> {
+                if (attributeValueMap.containsKey(k)){
+                    //Remove key value from attribute value map to be updated and add it as a key
+                    updateItem.addKeyEntry(k,attributeValueMap.get(k));
+                    attributeValueMap.remove(k);
+                }
+            });
+            //Set the rest of the attributes as attributes update
+            Map<String,AttributeValueUpdate> attributeValueUpdateMap = new HashMap<>();
+            attributeValueMap.forEach((k,v) -> attributeValueUpdateMap.put(k,new AttributeValueUpdate().withValue(v)));
+            updateItem.setAttributeUpdates(attributeValueUpdateMap);
+        } else {
+            throw new ConnectException("No top attribute name configured for " + valueSource + ", and it could not be converted to Map: " + attributeValue);
+        }
+    }
+
+    private void putItems(Collection<SinkRecord> records) throws UnprocessedItemsException {
+        if (records.size() == 1 || config.batchSize == 1) {
+            for (final SinkRecord record : records) {
+                client.putItem(tableName(record), toPutRequest(record).getItem());
+            }
+        } else {
+            final Iterator<SinkRecord> recordIterator = records.iterator();
+            while (recordIterator.hasNext()) {
+                final Map<String, List<WriteRequest>> writesByTable = toWritesByTable(recordIterator);
+                final BatchWriteItemResult batchWriteResponse = client.batchWriteItem(new BatchWriteItemRequest(writesByTable));
+                if (!batchWriteResponse.getUnprocessedItems().isEmpty()) {
+                    throw new UnprocessedItemsException(batchWriteResponse.getUnprocessedItems());
+                }
+            }
+        }
+    }
+
+    private void updateItems(Collection<SinkRecord> records){
+        for (final SinkRecord record : records) {
+            client.updateItem(toUpdateItemRequest(record).withTableName(tableName(record)));
+        }
+    }
+
+
+    private UpdateItemRequest toUpdateItemRequest(SinkRecord record) {
+        final UpdateItemRequest updateItem = new UpdateItemRequest();
+        if (!config.ignoreRecordValue) {
+            insertUpdate(ValueSource.RECORD_VALUE, record.valueSchema(), record.value(), updateItem);
+        }
+        if (!config.ignoreRecordKey) {
+            insertUpdate(ValueSource.RECORD_KEY, record.keySchema(), record.key(), updateItem);
+        }
+        if (config.kafkaCoordinateNames != null) {
+            updateItem.addAttributeUpdatesEntry(config.kafkaCoordinateNames.topic, new AttributeValueUpdate().withValue(new AttributeValue().withS(record.topic())));
+            updateItem.addAttributeUpdatesEntry(config.kafkaCoordinateNames.partition, new AttributeValueUpdate().withValue(new AttributeValue().withN(String.valueOf(record.kafkaPartition()))));
+            updateItem.addAttributeUpdatesEntry(config.kafkaCoordinateNames.offset, new AttributeValueUpdate().withValue(new AttributeValue().withN(String.valueOf(record.kafkaOffset()))));
+        }
+        return updateItem;
     }
 
     private String tableName(SinkRecord record) {


### PR DESCRIPTION
The connector currently only support putItem DynamoDB api.
putItem replaces the whole item.
If someone want to change only the available set of columns and leave the rest untouched it's not possible.

I added support for using the updateItem api.
In order to use it, one should use the following configurations:
use.updates = "true"
tables.keys.names = ["hash_key_attribute_name", "range_key_attribute_name"]

Change should be totally backward compatible.