### PR TITLE
use same version of aws sdk as confluent platform v.3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.11.65</version>
+            <version>1.11.86</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
I added `kafka-connect-dynamodb` to my Kafka Connect nodes and get the following error when trying to create an s3 connector.

```
com.amazonaws.services.s3.AmazonS3ClientBuilder.withAccelerateModeEnabled(Ljava/lang/Boolean;)Lcom/amazonaws/services/s3/AmazonS3Builder;
	at io.confluent.connect.s3.storage.S3Storage.newS3Client(S3Storage.java:63)
	at io.confluent.connect.s3.storage.S3Storage.<init>(S3Storage.java:59)
	... 15 more

```

The s3 connector is using 1.11.86 while the last released artifact is using 1.11.39.