### PR TITLE
Add support for document deletion, operation type and log level setup…

### DIFF
--- a/source-quickstart.properties
+++ b/source-quickstart.properties
@@ -1,3 +1,11 @@
 name=dynamodb-source-test
 connector.class=dynamok.source.DynamoDbSourceConnector
 region=us-west-2
+arn:aws:dynamodb:us-west-2:360292250396:table/ci_calltracking_campaign
+access.key.id=somekey
+secret.key=somesecret
+tables.prefix=
+tables.whitelist=helloworld
+tables.blacklist=
+topic.format=exampleupstream
+log.record.stream=True

--- a/src/main/java/dynamok/source/ConnectorConfig.java
+++ b/src/main/java/dynamok/source/ConnectorConfig.java
@@ -38,6 +38,7 @@ class ConnectorConfig extends AbstractConfig {
         static final String TABLES_WHITELIST = "tables.whitelist";
         static final String TABLES_BLACKLIST = "tables.blacklist";
         static final String TOPIC_FORMAT = "topic.format";
+        static final String LOG_RECORD_STREAM= "log.record.stream";
     }
 
     static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -59,7 +60,9 @@ class ConnectorConfig extends AbstractConfig {
             .define(Keys.TABLES_BLACKLIST, ConfigDef.Type.LIST, Collections.emptyList(),
                     ConfigDef.Importance.MEDIUM, "Blacklist for DynamoDB tables to source from.")
             .define(Keys.TOPIC_FORMAT, ConfigDef.Type.STRING, "${table}",
-                    ConfigDef.Importance.HIGH, "Format string for destination Kafka topic, use ``${table}`` as placeholder for source table name.");
+                    ConfigDef.Importance.HIGH, "Format string for destination Kafka topic, use ``${table}`` as placeholder for source table name.")
+            .define(Keys.LOG_RECORD_STREAM,ConfigDef.Type.STRING, "false",
+                    ConfigDef.Importance.LOW,"Enable record level logging of Dynamo stream.");
 
     final Regions region;
     final Password accessKeyId;
@@ -68,6 +71,7 @@ class ConnectorConfig extends AbstractConfig {
     final String tablesPrefix;
     final List<String> tablesWhitelist;
     final List<String> tablesBlacklist;
+    final String isRecordStreamLogOn;
 
     ConnectorConfig(Map<String, String> props) {
         super(CONFIG_DEF, props);
@@ -78,6 +82,7 @@ class ConnectorConfig extends AbstractConfig {
         tablesWhitelist = getList(Keys.TABLES_WHITELIST);
         tablesBlacklist = getList(Keys.TABLES_BLACKLIST);
         topicFormat = getString(Keys.TOPIC_FORMAT);
+        isRecordStreamLogOn = getString(Keys.LOG_RECORD_STREAM);
     }
 
     public static void main(String... args) {

--- a/src/main/java/dynamok/source/DynamoDbSourceConnector.java
+++ b/src/main/java/dynamok/source/DynamoDbSourceConnector.java
@@ -68,6 +68,7 @@ public class DynamoDbSourceConnector extends SourceConnector {
                 taskConfig.put(shard.getShardId() + "." + TaskConfig.Keys.TABLE, tableDesc.getTableName());
                 taskConfig.put(shard.getShardId() + "." + TaskConfig.Keys.STREAM_ARN, tableDesc.getLatestStreamArn());
             });
+            taskConfig.put(TaskConfig.Keys.LOG_RECORD_STREAM, config.isRecordStreamLogOn);
             return taskConfig;
         }).collect(Collectors.toList());
     }

--- a/src/main/java/dynamok/source/TaskConfig.java
+++ b/src/main/java/dynamok/source/TaskConfig.java
@@ -36,6 +36,7 @@ class TaskConfig {
         static String SHARDS = "shards";
         static String TABLE = "table";
         static String STREAM_ARN = "stream.arn";
+        static String LOG_RECORD_STREAM= "log.record.stream";
     }
 
     private final Map<String, String> props;
@@ -45,7 +46,7 @@ class TaskConfig {
     final String secretKey;
     final String topicFormat;
     final List<String> shards;
-
+    final Boolean isRecordStreamLogOn;
     TaskConfig(Map<String, String> props) {
         this.props = props;
 
@@ -54,6 +55,7 @@ class TaskConfig {
         secretKey = getValue(Keys.SECRET_KEY, "");
         topicFormat = getValue(Keys.TOPIC_FORMAT);
         shards = Arrays.stream(getValue(Keys.SHARDS).split(",")).filter(shardId -> !shardId.isEmpty()).collect(Collectors.toList());
+        isRecordStreamLogOn = Boolean.valueOf(getValue(Keys.LOG_RECORD_STREAM));
     }
 
     String tableForShard(String shardId) {


### PR DESCRIPTION
This add following features

1. Add OperationType in Keys attribute map. This help the Kafka consumer determine the Dynamodb operation type like - INSERT, MODIFY, REMOVE. 

2. Handle the deletion of data. In this case, the code doesn't attempt to get the new image, instead adds Keys with OperationType="REMOVE"

3. Add a logging flag in the properties file called log.record.stream. If this is true, code spits out the exact record retrieved from DynamoDB. This is useful in case of debugging but also if someone wants to monitor the data using ELK or Splunk.